### PR TITLE
make routing always go to route

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import Header from "./Header"
-import { defaultTestUser } from "../main";
 import { Link } from "react-router-dom";
 import { useAuth } from "@clerk/clerk-react";
 
@@ -20,7 +19,6 @@ function Favorites() {
                     "Authorization": `Bearer ${await getToken()}`
 
                 },
-                body: JSON.stringify({ id: defaultTestUser.id }),
             }).then(res => res.json()).then((data) => {
                 setFavorites(data)
             }).catch((error) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,14 +14,6 @@ import { ClerkProvider } from '@clerk/clerk-react'
 
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-
-export const defaultTestUser = {
-  id: 'clxm4hnxg0000127n543sm1js',
-  email: 'alice@prisma.io',
-  name: 'Alice',
-  avatar_url: 'link.com'
-}
-
 const router = createBrowserRouter([
   {
     path: "/",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 181f50f209d7bcf4b83e228c01b66fbb0be7b3d9  | 
|--------|--------|

### Summary:
Added Netlify redirect configuration and removed hardcoded test user from `Favorites` component.

**Key points**:
- Added `netlify.toml` to redirect all routes to `/index.html` with status `200`.
- Removed `defaultTestUser` from `src/main.tsx`.
- Updated `src/components/Favorites.tsx` to remove the use of `defaultTestUser` in the fetch request body.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->